### PR TITLE
feat : 메일 읽기 기능 모드에서 메일 삭제 기능 구현 (#29)

### DIFF
--- a/src/main/java/deu/cse/spring_webmail/control/ReadController.java
+++ b/src/main/java/deu/cse/spring_webmail/control/ReadController.java
@@ -65,6 +65,7 @@ public class ReadController {
         session.setAttribute("subject", pop3.getSubject());
         session.setAttribute("body", pop3.getBody());
         model.addAttribute("msg", msg);
+        model.addAttribute("msgid", msgid);
         return "/read_mail/show_message";
     }
     

--- a/src/main/webapp/WEB-INF/views/read_mail/sidebar_read_menu.jsp
+++ b/src/main/webapp/WEB-INF/views/read_mail/sidebar_read_menu.jsp
@@ -19,6 +19,7 @@
             <strong>사용자: <%= session.getAttribute("userid") %> </strong>
         </span> <br> <br>
         
+        <p><a href="delete_mail.do?msgid=${msgid}"> 메일 삭제 </a></p>
         <p><a href="write_mail?sender=<%= session.getAttribute("sender") %>"> 답장 하기 </a></p>
         <p><a href="main_menu"> 이전 메뉴로 </a></p>
     </body>


### PR DESCRIPTION
### ✒️ #29 

- Closes 메일 읽기 기능 모드에서 메일 삭제 기능 구현 #29 

## 🔑 Key Changes

1. ReadController & sidebar_read_menu.jsp
    - 세부 메일 화면에 삭제 버튼 추가
    - view에서 메일 삭제하는 기존 코드로 연결하여 @GetMapping으로 삭제할 수 있도록 구현하기

## 📢 To Reviewers

- 변경 내용 이외에 코드에 대한 전달 사항
