### PR TITLE
fix : messageToInbox error (#37)

### DIFF
--- a/src/test/java/deu/cse/spring_webmail/unittest/InboxRepositoryTest.java
+++ b/src/test/java/deu/cse/spring_webmail/unittest/InboxRepositoryTest.java
@@ -71,7 +71,7 @@ class InboxRepositoryTest {
     @Test
     void messageToInbox(){        
 
-        Inbox inbox = repository.findByRepositoryNameAndSenderAndMessageBody("test2","test","wta","dd");
+        Inbox inbox = repository.findByRepositoryNameAndSenderAndMessageBody("test2","test","dd");
         log.info("inbox info ={}",inbox.getId().getMessageName());
         Recyclebin recyclebin = Recyclebin.builder().inboxId(inbox.getId())
                 .lastUpdated(inbox.getLastUpdated())


### PR DESCRIPTION
### ✒️ 관련 이슈번호

- Closes #37 

## 🔑 Key Changes

1. messageToInbox 메소드 내부에 repository.findByRepositoryNameAndSenderAndMessageBody 매개변수 수정
    - InboxRepository 수정으로 인해 수정하였습니다.

## 📢 To Reviewers

- 변경 내용 이외에 코드에 대한 전달 사항
